### PR TITLE
update_readme and sln

### DIFF
--- a/SimpleShop.sln
+++ b/SimpleShop.sln
@@ -2,11 +2,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.34707.107
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleShop.AppHost", "SimpleShop.AppHost\SimpleShop.AppHost.csproj", "{FB94A87F-E655-4D49-A382-93C9F96FC4FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleShop.AppHost", "SimpleShop.AppHost\SimpleShop.AppHost.csproj", "{FB94A87F-E655-4D49-A382-93C9F96FC4FD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimpleShop.ServiceDefaults", "SimpleShop.ServiceDefaults\SimpleShop.ServiceDefaults.csproj", "{C5E1DFBF-51E0-475D-8D34-9149A91F0648}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatalogDB", "CatalogDB\CatalogDB.csproj", "{3D023FCE-4A46-419E-A38F-5E7D8CDEDD18}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CatalogDB", "CatalogDB\CatalogDB.csproj", "{3D023FCE-4A46-419E-A38F-5E7D8CDEDD18}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CatalogDbManager", "CatalogDbManager\CatalogDbManager.csproj", "{8097B051-811F-4040-8ABE-19F7A00DA39A}"
 EndProject
@@ -15,6 +15,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasketService", "BasketService\BasketService.csproj", "{DAD4110D-E72C-4D6D-B9E3-733BA2F0B8D2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Frontend", "Frontend\Frontend.csproj", "{4CF6908E-7C28-44C0-B421-0C76412565CF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F444F715-0BD7-48BE-94D1-D790C579DA08}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This pull request includes changes to the `SimpleShop.sln` solution file, specifically updating the project GUIDs and adding a new "Solution Items" project.

Here are the most important changes:

* [`SimpleShop.sln`](diffhunk://#diff-0b6239edc7fac13806ac19f7bcf98f10017b9feab052fa95ecdf5e05974cfa97L5-R9): Updated the project GUID for "SimpleShop.AppHost" and "CatalogDB" from `{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}` to `{9A19103F-16F7-4668-BE54-9A1E7A4F7556}`. This change is likely due to a change in the project type or a migration to a newer version of Visual Studio.
* [`SimpleShop.sln`](diffhunk://#diff-0b6239edc7fac13806ac19f7bcf98f10017b9feab052fa95ecdf5e05974cfa97R19-R23): Added a new "Solution Items" project, which includes the `README.md` file. This is a common way to include non-code files that are important for the solution, like documentation or configuration files.