### PR TITLE
Update azure-dev.yml

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -28,6 +28,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      
+      - name: Restore workloads
+        run:  dotnet workload restore  
   
       - name: Install azd
         uses: Azure/setup-azd@v1.0.0


### PR DESCRIPTION
This pull request introduces changes to the `.github/workflows/azure-dev.yml` file, specifically in the `jobs:` section. The changes include the addition of steps to setup .NET and restore workloads before installing azd.

The most important changes are:

* [`.github/workflows/azure-dev.yml`](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7R32-R39): Added a step to setup .NET using `actions/setup-dotnet@v4` and specified the `dotnet-version` as `8.0.x`. Following this, another step was added to restore workloads using `dotnet workload restore`. These steps are executed before the installation of azd.