### PR TITLE
Bump Aspire.Hosting and Aspire.Hosting.PostgreSQL versions

### DIFF
--- a/CatalogDB/CatalogDB.csproj
+++ b/CatalogDB/CatalogDB.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.5.24201.12" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
   </ItemGroup>
 
 </Project>

--- a/SimpleShop.AppHost/SimpleShop.AppHost.csproj
+++ b/SimpleShop.AppHost/SimpleShop.AppHost.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.6.24214.1" />
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.5.24201.12" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.6.24214.1" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0-preview.5.24201.12" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0-preview.6.24214.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes updates to the versions of several packages in two project files. The packages `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL`, `Aspire.Hosting.AppHost`, and `Aspire.Hosting.Redis` have been upgraded to the `8.0.0-preview.6.24214.1` version in both `CatalogDB/CatalogDB.csproj` and `SimpleShop.AppHost/SimpleShop.AppHost.csproj` files.

Package updates:

* [`CatalogDB/CatalogDB.csproj`](diffhunk://#diff-0ff8bea06ee0444236847f86ab4d63f57d6e5b85e9d6860ed30e93bd799802cdL10-R10): Updated `Aspire.Npgsql.EntityFrameworkCore.PostgreSQL` package to version `8.0.0-preview.6.24214.1`.
* [`SimpleShop.AppHost/SimpleShop.AppHost.csproj`](diffhunk://#diff-7e90ea6bf8046c8c740869cc3280f8fb4e76f2714a95089ecdce212e48dea4f9L13-R15): Updated `Aspire.Hosting.AppHost` and `Aspire.Hosting.Redis` packages to version `8.0.0-preview.6.24214.1`.